### PR TITLE
Bump Tether to v1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/danreeves/react-tether",
   "dependencies": {
     "prop-types": "^15.5.8",
-    "tether": "^1.3.7"
+    "tether": "^1.4.3"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",


### PR DESCRIPTION
Includes a bugfix which was making our apps that use `react-tether` unusable on older Safari versions.